### PR TITLE
Release to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 ### ttag-po-loader
-Webpack loader for .po files for ttag
+Webpack loader for Portable Object (`.po`) files for `ttag`.
 
 A working proof of concept for https://github.com/ttag-org/ttag-webpack-plugin/issues/8
 
 #### Installation
 
 ```console
-> yarn add --dev https://github.com/dimaqq/ttag-po-loader
-> yarn add --dev ttag-cli
+> yarn add --dev ttag-po-loader
 ```
 
-### Use
+#### Use
 ```js
 import {addLocale} from "ttag";
 import en_GB from "somewhere/en-GB.po";
@@ -21,15 +20,13 @@ addLocale("en-GB`", en_GB);
 #### Webpack rules
 
 ```js
-draft.module.rules.push({
-  test: [/\.po$/],
-  loader: "ttag-po-loader",
+// 1. Tell webpack how to load PO files
+config.module.rules.push({
+test: [/\.po$/],
+loader: "ttag-po-loader",
 });
-```
 
-P.S. make sure `.po` file extension is not covered by `file-loader`, for example for CRA, override:
-
-```js
-const loaders = draft.module.rules.find(r => r.oneOf).oneOf;
-loaders.find(o => o?.loader?.match(/file-loader/)).exclude.push(/[.]po$/);
+// 2. Exempt PO files from default rules if you use create-react-app
+const loaders = config.module.rules.find(r => r.oneOf).oneOf;
+loaders.find(l => l?.loader?.match(/file-loader/)).exclude.push(/[.]po$/);
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A working proof of concept for https://github.com/ttag-org/ttag-webpack-plugin/i
 #### Installation
 
 ```console
-> yarn add --dev ttag-po-loader
+yarn add --dev ttag-po-loader
 ```
 
 #### Use

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "license": "MIT",
   "dependencies": {
     "ttag-cli": "^1"
+  },
+  "publishConfig": {
+    "tag": "experimental"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttag-po-loader",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Webpack loader for .po files for ttag",
   "main": "index.js",
   "repository": "https://github.com/dimaqq/ttag-po-loader",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ttag-po-loader",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Webpack loader for .po files for ttag",
   "main": "index.js",
-  "repository": "https://github.com/dimaqq/ttag-po-loader",
+  "repository": "https://github.com/ttag-org/ttag-po-loader",
   "author": "Dima Tisnek <dimaqq@gmail.com>",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "main": "index.js",
   "repository": "https://github.com/dimaqq/ttag-po-loader",
   "author": "Dima Tisnek <dimaqq@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "ttag-cli": "^1"
+  }
 }


### PR DESCRIPTION
Prepare to release to npm.
Currently released as `0.0.2` with tags `experimental` and `latest` 🤦‍♂️
A sample project using the library from npm is here: https://github.com/dimaqq/ttag-po-loader-sample
Close #1, close #2.